### PR TITLE
add typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+type GitRevisionTypes =
+  'short' |
+  'long' |
+  'hash' |
+  'tag'
+
+declare function gitRevision(type: GitRevisionTypes): string
+declare function gitRevision(type: GitRevisionTypes, onComplete: (hash: string) => void): void
+
+export = gitRevision


### PR DESCRIPTION
Adds typescript typings for `git-revision`

They are a little basic but when you only export one function its all it needs.

Users need to use:

```ts
import gitRevision = require('git-revision')
```

for it to work properly as it's not an ES6 module.